### PR TITLE
feat: support wsl path

### DIFF
--- a/package.json
+++ b/package.json
@@ -201,7 +201,8 @@
     },
     "dependencies": {
         "joi": "^17.6.0",
-        "open": "8.4.0"
+        "open": "8.4.0",
+        "wsl-path": "^3.0.0"
     },
     "devDependencies": {
         "@nuxt/friendly-errors-webpack-plugin": "^2.5.2",


### PR DESCRIPTION
try to fix #16 

convert wsl path to windows path using `wsl-path` package (which uses the builtin `wslpath` command)
only works for `open`, not VSCode api `openExternal` 
currently supports only 1 wsl environment, multiple environments can be supported by changing `wslCommand`