### PR TITLE
feat: Add short pathSeparator alias

### DIFF
--- a/src/utils/variable.ts
+++ b/src/utils/variable.ts
@@ -16,6 +16,7 @@ export async function parseVariables(strList: string[], activeFile?: Uri) {
     > = new Map([
         ['${userHome}', homedir()],
         ['${pathSeparator}', path.sep],
+        ['${/}', path.sep],
     ]);
 
     const { workspaceFolders } = vscode.workspace;


### PR DESCRIPTION
Visual Studio Code has a predefined variable ${pathSeparator} that represents the path separator on the current platform. It has a shorter alias ${/}.

This commit adds support for the short alias to the extension path handler.