### PR TITLE
fix: workaround vscode.env.openExternal non-ASCII path issue on Windows

### DIFF
--- a/src/utils/open.ts
+++ b/src/utils/open.ts
@@ -25,6 +25,13 @@ function openByPkg(filePath: string, options?: OpenOptions) {
 async function openByBuiltinApi(filePath: string) {
     logger.info('open file by vscode builtin api');
     // https://github.com/microsoft/vscode/issues/88273
+    // On Windows, vscode.env.openExternal cannot handle non-ASCII characters (e.g. Chinese) in file paths.
+    // Fallback to open pkg which uses ShellExecute and handles Unicode paths correctly.
+    // eslint-disable-next-line no-control-regex
+    if (isWindows && /[^\u0000-\u007F]/.test(filePath)) {
+        logger.info('file path contains non-ASCII characters, fallback to open pkg on Windows');
+        return openByPkg(filePath);
+    }
     return vscode.env.openExternal(Uri.file(filePath));
 }
 
@@ -56,7 +63,10 @@ export async function open(filePath: string, appConfig?: string | ExternalAppCon
             const parsedCommand = (
                 await parseVariables([appConfig.shellCommand!], Uri.file(convertedPath))
             )[0];
-            logger.info(`open file by shell command: "${parsedCommand}"`);
+            // On Windows, switch console codepage to UTF-8 (65001) so that
+            // non-ASCII characters (e.g. Chinese) in file paths are handled correctly.
+            const finalCommand = isWindows ? `chcp 65001 > nul && ${parsedCommand}` : parsedCommand;
+            logger.info(`open file by shell command: "${finalCommand}"`);
             try {
                 if (appConfig.shellEnv) {
                     const shellEnv = getShellEnv();
@@ -74,13 +84,13 @@ export async function open(filePath: string, appConfig?: string | ExternalAppCon
 
                     await mergeEnvironments(shellEnv, additionalEnv, Uri.file(convertedPath));
                     const options: ExecOptions = { env: shellEnv };
-                    await exec(parsedCommand, options);
+                    await exec(finalCommand, options);
                 } else {
-                    await exec(parsedCommand);
+                    await exec(finalCommand);
                 }
             } catch (error: any) {
                 vscode.window.showErrorMessage(
-                    `open file by shell command failed, execute: "${parsedCommand}"`,
+                    `open file by shell command failed, execute: "${finalCommand}"`,
                 );
                 logger.info(error);
             }
@@ -94,6 +104,10 @@ export async function open(filePath: string, appConfig?: string | ExternalAppCon
             });
         }
     } else if (vscode.env.remoteName === 'wsl') {
+        await openByPkg(convertedPath);
+    } else if (isWindows) {
+        // On Windows, prefer open pkg over vscode builtin api to avoid
+        // non-ASCII (e.g. Chinese) file path issues with vscode.env.openExternal
         await openByPkg(convertedPath);
     } else {
         await openByBuiltinApi(convertedPath);


### PR DESCRIPTION
On Windows, `vscode.env.openExternal(Uri.file(filePath))` silently fails when the file path contains non-ASCII characters (e.g. Chinese), due to a known bug in the underlying Electron/VS Code implementation.

Additionally, the default codepage of `cmd.exe` on Windows is GBK (936), which causes garbled characters when Node.js passes UTF-8 encoded paths (containing Chinese) to shell commands via `exec()` -- causing a "the system cannot find the file specified" error.

This commit works around both issues:

- In `openByBuiltinApi`: detect non-ASCII paths on Windows and fall back to the `open` pkg, which uses ShellExecute and handles Unicode natively.
- In `shellCommand` execution: prepend `chcp 65001 > nul &&` on Windows to switch cmd.exe to UTF-8 codepage before running the command.
- In the default no-config path: use `open` pkg instead of the VS Code builtin API on Windows to avoid the same Unicode issue.

All changes are guarded by `isWindows`, so macOS and Linux are unaffected.

Ref: microsoft/vscode#88273

(Claude Sonnet 4.6 Fix and Write Commit)